### PR TITLE
Optional bowtie build

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -62,9 +62,13 @@ process {
         publishDir = [ enabled: false ]
     }
     withName: 'BOWTIE2_BUILD' {
+        // Check if the Bowtie2 index exists and skip if it does
+        process.when = !new File(params.bowtie2_db + '.1.bt2').exists()
+
         storeDir = { new File(params.bowtie2_db).getParent() } // Note: versions.yml needs to be there too.
         ext.args = '--large-index'
     }
+
     withName: '.*:FASTQ_ALIGN_BOWTIE2:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:.*' {
         publishDir = [ enabled: false ]
     }
@@ -281,13 +285,12 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-    withName: 'SAMTOOLS_FAIDX' {
-        publishDir = [ enabled: false ]
-    }
     withName: '.*:AMETA:SAMTOOLS_FAIDX' {
-        // This tries to write in the same directory as the bowtie2 build indices.
-        // The versions.yml will get overwritten, and will cause a problem with versions collection later
-        // storeDir   = { new File(params.bowtie2_db).getParent() } // Note: versions.yml should also be present.
+        // Check if the faidx index exists and skip the process if it does
+        process.when = !new File(params.bowtie2_db + '.fai').exists()
+    
+        // Disable publishing to avoid writing to the bowtie2 directory
+        publishDir = [ enabled: false ]
     }
 
     // SUBWORKFLOW: summary

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -284,6 +284,11 @@ process {
     withName: 'SAMTOOLS_FAIDX' {
         publishDir = [ enabled: false ]
     }
+    withName: '.*:AMETA:SAMTOOLS_FAIDX' {
+        // This tries to write in the same directory as the bowtie2 build indices.
+        // The versions.yml will get overwritten, and will cause a problem with versions collection later
+        // storeDir   = { new File(params.bowtie2_db).getParent() } // Note: versions.yml should also be present.
+    }
 
     // SUBWORKFLOW: summary
     withName: 'PLOTAUTHENTICATIONSCORE' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -62,6 +62,7 @@ process {
         publishDir = [ enabled: false ]
     }
     withName: 'BOWTIE2_BUILD' {
+        storeDir = { new File(params.bowtie2_db).getParent() } // Note: versions.yml needs to be there too.
         ext.args = '--large-index'
     }
     withName: '.*:FASTQ_ALIGN_BOWTIE2:BAM_SORT_STATS_SAMTOOLS:BAM_STATS_SAMTOOLS:.*' {


### PR DESCRIPTION
<!--
# nf-core/ameta pull request

Many thanks for contributing to nf-core/ameta!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/ameta/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

Partially resolves #4. 
Writes out the bowtie2 indices (and versions.yml) to the same directory as the fasta input. If this directory is used again in another run, the cached index will be used instead of rerunning the process.

The same cannot be done for samtools faidx (yet) because it's a separate process which writes it's own versions.yml. These
versions.yml are used later on for collecting versions information. Over the summer, the nf-core modules will go through a restructure making the `versions.yml` obsolete meaning the `storeDir` solution can then be used. It's currently included as a comment.

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/ameta/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/ameta _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
